### PR TITLE
Updated how-to-build with Ubuntu 22.04

### DIFF
--- a/.github/workflows/build_from_source.yml
+++ b/.github/workflows/build_from_source.yml
@@ -20,7 +20,7 @@ jobs:
         cd $HOME/faiss
 
         echo "##### Check ldd of .so #####"
-        ldd build/faiss/libfaiss.so
+        ldd build/faiss/libfaiss_avx2.so
 
         echo "##### Run c++ test #####"        
         make -C build -j demo_ivfpq_indexing

--- a/.github/workflows/build_from_source.yml
+++ b/.github/workflows/build_from_source.yml
@@ -20,7 +20,7 @@ jobs:
         cd $HOME/faiss
 
         echo "##### Check ldd of .so #####"
-        ldd build/faiss/libfaiss_avx2.so
+        ldd build/faiss/libfaiss.so
 
         echo "##### Run c++ test #####"        
         make -C build -j demo_ivfpq_indexing
@@ -30,5 +30,3 @@ jobs:
         cd
         python -c "import faiss, numpy; err = faiss.Kmeans(10, 20).train(numpy.random.rand(1000, 10).astype('float32')); print(err)"
 
-        echo "##### AVX2 is activated or not #####"
-        LD_DEBUG=libs python -c "import faiss" 2>&1 | grep libfaiss_avx2.so

--- a/.github/workflows/build_from_source.yml
+++ b/.github/workflows/build_from_source.yml
@@ -30,3 +30,39 @@ jobs:
         cd
         python -c "import faiss, numpy; err = faiss.Kmeans(10, 20).train(numpy.random.rand(1000, 10).astype('float32')); print(err)"
 
+        echo "##### Check AVX2 is working or not #####"        
+        echo "import faiss
+        import numpy as np
+        import time
+
+        np.random.seed(123)
+        D = 128
+        N = 1000
+        X = np.random.random((N, D)).astype(np.float32)
+        M = 64
+        nbits = 4
+
+        pq = faiss.IndexPQ(D, M, nbits)
+        pq.train(X)
+        pq.add(X)
+
+        pq_fast = faiss.IndexPQFastScan(D, M, nbits)
+        pq_fast.train(X)
+        pq_fast.add(X)
+
+        t0 = time.time()
+        d1, ids1 = pq.search(x=X[:3], k=5)
+        t1 = time.time()
+        print(f'pq: {(t1 - t0) * 1000} msec')
+
+        t0 = time.time()
+        d2, ids2 = pq_fast.search(x=X[:3], k=5)
+        t1 = time.time()
+        print(f'pq_fast: {(t1 - t0) * 1000} msec')
+
+        assert np.allclose(ids1, ids2)
+        " > check.py
+        python check.py
+
+
+

--- a/.github/workflows/build_from_source.yml
+++ b/.github/workflows/build_from_source.yml
@@ -30,14 +30,16 @@ jobs:
         cd
         python -c "import faiss, numpy; err = faiss.Kmeans(10, 20).train(numpy.random.rand(1000, 10).astype('float32')); print(err)"
 
-        echo "##### Check AVX2 is working or not #####"        
+        echo "##### Check AVX2 is working or not #####"      
+        LD_DEBUG=libs python -c "import faiss" 2>&1 | grep libfaiss_avx2.so  
+
         echo "import faiss
         import numpy as np
         import time
 
-        np.random.seed(123)
+        np.random.seed(234)
         D = 128
-        N = 1000
+        N = 10000
         X = np.random.random((N, D)).astype(np.float32)
         M = 64
         nbits = 4

--- a/build.md
+++ b/build.md
@@ -59,6 +59,8 @@ Currently, cmake from apt is old (3.16 for Ubuntu 20.04, and 3.22 for Ubuntu 22.
     ```bash
     conda install -c anaconda cmake 
     ```
+- [Use APT repository](https://askubuntu.com/a/1157132). Seems easy. Not tested by myself though.
+
 
 ### miniconda
 We will use miniconda for python. See [this](https://conda.io/projects/conda/en/latest/user-guide/install/macos.html#install-macos-silent) for the instruction of the silent installation.

--- a/build.md
+++ b/build.md
@@ -55,6 +55,7 @@ Currently, cmake from apt is old (3.16 for Ubuntu 20.04, and 3.22 for Ubuntu 22.
     ```bash
     sudo snap install cmake --classic
     ```
+    Note that WSL recently supported snap. See [this](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/#set-the-systemd-flag-set-in-your-wsl-distro-settings).
 - If you've installed conda, you can install cmake by conda.
     ```bash
     conda install -c anaconda cmake 
@@ -165,6 +166,7 @@ Then let's install the module on your python.
 cd build/faiss/python
 python setup.py install
 ```
+This will update your python environment (You can uninstall it by `pip uninstall faiss`).
 
 Finally, you need to specify the PYTHONPATH. Activate it, and write it on `~/.bashrc`.
 ```bash

--- a/build.md
+++ b/build.md
@@ -2,7 +2,7 @@
 This document is a step-by-step instruction for building faiss from the source. We assume:
 - x86 architecture
 - CPU
-- Ubuntu 20.04 
+- Ubuntu 22.04 
 - miniconda for python environment
 - Intel MKL (we can install it simply by `apt` for Ubuntu 20.04 or higher)
 - AVX2
@@ -49,19 +49,16 @@ If you cannot install intel-mkl, you can use open-blas by `sudo apt install -y l
 
 
 ### cmake
- 
 Currently, cmake from apt is old (3.16 for Ubuntu 20.04, and 3.22 for Ubuntu 22.04). For faiss 1.7+, we need cmake 3.23+. There are three options to install new cmake.
 - Build from source
 - Install by snap. This is the easiest.
     ```bash
     sudo snap install cmake --classic
     ```
-    Note that WSL recently supported snap. See [this](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/#set-the-systemd-flag-set-in-your-wsl-distro-settings).
 - If you've installed conda, you can install cmake by conda.
     ```bash
     conda install -c anaconda cmake 
     ```
-- [Use APT repository](https://askubuntu.com/a/1157132). Seems easy. Not tested by myself though.
 
 ### miniconda
 We will use miniconda for python. See [this](https://conda.io/projects/conda/en/latest/user-guide/install/macos.html#install-macos-silent) for the instruction of the silent installation.
@@ -118,13 +115,13 @@ In the log message, you will find that the cmake correctly located the MKL: `-- 
 
 Then, run make to build the library.
 ```bash
-make -C build -j faiss
+make -C build -j faiss faiss_avx2
 ```
-This will create `build/faiss/libfaiss.so`.
+This will create `build/faiss/libfaiss.so` and `build/faiss/libfaiss_avx2.so`. I'm not sure about this part, but we need to specify `faiss_avx2` as well manually.
 
 Let's check the link information by:
 ```bash
-ldd build/faiss/libfaiss.so
+ldd build/faiss/libfaiss_avx2.so
 ```
 This will show something like:
 ```bash
@@ -152,11 +149,12 @@ make -C build -j demo_ivfpq_indexing
 ```
 It takes 7 sec for AWS EC2 c5.12xlarge: `[7.298 s] Query results (vector ids, then distances):`.
 
+Note that `demo_ivfpq_indexing` uses `libfaiss.so`. If you want to use `libfaiss_avx2.so`, please rewrite `target_link_libraries(demo_ivfpq_indexing PRIVATE faiss)` to `target_link_libraries(demo_ivfpq_indexing PRIVATE faiss_avx2)` in `$HOME/faiss/demos/CMakeLists.txt`.
 
 
 Then let's build the python module. Run the following.
 ```bash
-make -C build -j swigfaiss
+make -C build -j swigfaiss swigfaiss_avx2
 ```
 This will create files on `build/faiss/python`.
 
@@ -165,7 +163,6 @@ Then let's install the module on your python.
 cd build/faiss/python
 python setup.py install
 ```
-This will update your python environment (You can uninstall it by `pip uninstall faiss`).
 
 Finally, you need to specify the PYTHONPATH. Activate it, and write it on `~/.bashrc`.
 ```bash
@@ -183,21 +180,20 @@ You will see something like `483.5049743652344`.
 
 
 ## Check AVX2 is working or not
-Let's check AVX2 is activated or not. First, you can see the path information of `libfaiss.so` from python by
+Let's check AVX2 is activated or not.
 
 ```bash
 cd
 LD_DEBUG=libs python -c "import faiss" 2>&1 | grep libfaiss.so
 ```
-You will see something like
-```console
-      ...
-      4886:       trying file=haswell/libfaiss.so
-      4886:       trying file=avx512_1/x86_64/libfaiss.so
-      4886:       trying file=avx512_1/libfaiss.so
-      4886:       trying file=x86_64/libfaiss.so
-      ...
+If you see something, then your AVX2 **is not** activated.
+
+Run the following as well
+```bash
+cd
+LD_DEBUG=libs python -c "import faiss" 2>&1 | grep libfaiss_avx2.so
 ```
+If you see something, then your AVX2 **is** activated.
 
 To actually evaluate the runtime, please save the following as `check.py`.
 This code compares `IndexPQ` and `IndexPQFastScan`. Here, `IndexPQFastScan` is a faster (approximated) version of `IndexPQ` with SIMD instructions (AVX2 for usual x86 computers).
@@ -206,9 +202,9 @@ import faiss
 import numpy as np
 import time
 
-np.random.seed(123)
+np.random.seed(234)
 D = 128
-N = 1000
+N = 10000
 X = np.random.random((N, D)).astype(np.float32)
 M = 64
 nbits = 4

--- a/build.md
+++ b/build.md
@@ -237,8 +237,8 @@ assert np.allclose(ids1, ids2)
 Then run `python check.py`.
 If AVX2 is properly activated, pq_fast should be roughly 10x faster:
 ```bash
-pq: 0.5166530609130859 msec
-pq_fast: 0.06580352783203125 msec
+pq: 1.8916130065917969 msec
+pq_fast: 0.1723766326904297 msec
 ```
 
 

--- a/build.sh
+++ b/build.sh
@@ -24,9 +24,9 @@ cmake -B build \
     -DPython_EXECUTABLE=$HOME/miniconda/bin/python \
     -DCMAKE_BUILD_TYPE=Release .
 
-make -C build -j faiss
+make -C build -j faiss faiss_avx2
 
-make -C build -j swigfaiss
+make -C build -j swigfaiss swigfaiss_avx2
 
 cd build/faiss/python
 python setup.py install

--- a/build.sh
+++ b/build.sh
@@ -24,9 +24,9 @@ cmake -B build \
     -DPython_EXECUTABLE=$HOME/miniconda/bin/python \
     -DCMAKE_BUILD_TYPE=Release .
 
-make -C build -j faiss faiss_avx2
+make -C build -j faiss
 
-make -C build -j swigfaiss swigfaiss_avx2
+make -C build -j swigfaiss
 
 cd build/faiss/python
 python setup.py install


### PR DESCRIPTION
Updated outdated information for the building. Tested on (1) WSL2 with Ubuntu 22.04 and (2) GitHub actions

- Update how-to-install cmake; (1) snap for WSL and (2) APT
- ~~We don't need the `***_avx2` files anymore. So remove them.~~   We still need it!
- For IndexFastPQ, (1) increase the number of vectors in order to highlight the speedup, and (2) run the avx2 bench in CI as well