### PR TITLE
Added exit with non-zero value on build failure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,9 +24,24 @@ cmake -B build \
     -DPython_EXECUTABLE=$HOME/miniconda/bin/python \
     -DCMAKE_BUILD_TYPE=Release .
 
+if [ $? -ne 0 ]; then
+    echo "Error: CMake build failed"
+    exit 1
+fi
+
 make -C build -j faiss faiss_avx2
 
+if [ $? -ne 0 ]; then
+    echo "Error: Building C++ library failed"
+    exit 1
+fi
+
 make -C build -j swigfaiss swigfaiss_avx2
+
+if [ $? -ne 0 ]; then
+    echo "Error: Building Python bindings failed"
+    exit 1
+fi
 
 cd build/faiss/python
 python setup.py install


### PR DESCRIPTION
Added non-zero exit on build failure.
This shows error in the build step of github actions workflow as can be seen in https://github.com/kaushikacharya/faiss_tips/actions/runs/17413270668/job/49435493255